### PR TITLE
spec plan was fine the way it was

### DIFF
--- a/cmd/speculative_plan.go
+++ b/cmd/speculative_plan.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/logandavies181/tfd/v2/cmd/config"
 	"github.com/logandavies181/tfd/v2/cmd/flags"
@@ -33,10 +32,7 @@ var speculativePlanCmd = &cobra.Command{
 			Workspace: viper.GetString("workspace"),
 		}
 
-		err = speculativePlan(config)
-		if err != nil {
-			os.exit(1)
-		}
+		return speculativePlan(config)
 	},
 }
 


### PR DESCRIPTION
Returning an error to RunE causes cobra to os.Exit(1) already