### PR TITLE
Add "root-path" parameter to override git workspace root

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ tfd list-workspaces
 # Upload local git repo to Terraform Cloud
 tfd upload-config --path /path/to/project --workspace myworkspace
 
-# Upload local root folder to Terraform Cloud
-tfd upload-config --root-path /path/to/root --path /path/to/root/path/to/project --workspace myworkspace
+# Upload non-git folder to Terraform Cloud or override git root
+tfd upload-config --root-path /path/to/root --workspace myworkspace
 
 # Start a run
 tfd run start --workspace myworkspace

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ tfd list-workspaces
 tfd upload-config --path /path/to/project --workspace myworkspace
 
 # Upload non-git folder to Terraform Cloud or override git root
-tfd upload-config --root-path /path/to/root --workspace myworkspace
+tfd upload-config --rootpath /path/to/root --workspace myworkspace
 
 # Start a run
 tfd run start --workspace myworkspace

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ tfd list-workspaces
 # Upload local git repo to Terraform Cloud
 tfd upload-config --path /path/to/project --workspace myworkspace
 
+# Upload local root folder to Terraform Cloud
+tfd upload-config --root-path /path/to/root --path /path/to/root/path/to/project --workspace myworkspace
+
 # Start a run
 tfd run start --workspace myworkspace
 

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -2,6 +2,8 @@ package flags
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -68,7 +70,26 @@ func AddNoClobberFlag(cmd *cobra.Command) {
 }
 
 func AddPathFlag(cmd *cobra.Command) {
-	cmd.Flags().StringP("path", "p", "", "Path to project. Can be any subdirectory of the project, but it must be a git project")
+	cmd.Flags().StringP("path", "p", "", "Path to project. Can be any subdirectory of the workspace root")
+}
+
+func AddRootPathFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP("rootpath", "", "", "Path to workspace root. Defaults to the folder detected by git as the workspace root")
+
+	addValidation(cmd.Name(), func() error {
+		rootPath := viper.GetString("rootpath")
+		if rootPath == "" {
+			return nil
+		}
+		stat, err := os.Stat(rootPath)
+		if err != nil {
+			return errors.Wrapf(err, "tfd: error accessing rootPath")
+		}
+		if !stat.IsDir() {
+			return errors.Errorf("tfd: rootPath '%s' is not a directory", rootPath)
+		}
+		return nil
+	})
 }
 
 func AddRefreshFlag(cmd *cobra.Command) {

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -86,7 +86,7 @@ func AddRootPathFlag(cmd *cobra.Command) {
 			return fmt.Errorf("error accessing rootPath: %w", err)
 		}
 		if !stat.IsDir() {
-			return errors.Errorf("tfd: rootPath '%s' is not a directory", rootPath)
+			return fmt.Errorf("tfd: rootPath '%s' is not a directory", rootPath)
 		}
 		return nil
 	})

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -1,8 +1,8 @@
 package flags
 
 import (
+	"errors"
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -83,7 +83,7 @@ func AddRootPathFlag(cmd *cobra.Command) {
 		}
 		stat, err := os.Stat(rootPath)
 		if err != nil {
-			return errors.Wrapf(err, "tfd: error accessing rootPath")
+			return fmt.Errorf("error accessing rootPath: %w", err)
 		}
 		if !stat.IsDir() {
 			return errors.Errorf("tfd: rootPath '%s' is not a directory", rootPath)

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"errors"
 	"fmt"
 	"os"
 

--- a/cmd/flags/flags_test.go
+++ b/cmd/flags/flags_test.go
@@ -16,6 +16,7 @@ func TestUnvalidatedFlags(t *testing.T) {
 		Use: testCommandName,
 	}
 	AddPathFlag(cmd)
+	AddRootPathFlag(cmd)
 	AddAutoApplyFlag(cmd)
 	AddMessageFlag(cmd)
 	AddWatchFlag(cmd)

--- a/cmd/speculative_plan.go
+++ b/cmd/speculative_plan.go
@@ -89,7 +89,6 @@ func speculativePlan(cfg speculativePlanConfig) error {
 		}
 	}
 
-	fmt.Println("[debug] speculative plan, root path:", pathToRoot)
 	err = cfg.Client.ConfigurationVersions.Upload(cfg.Ctx, cv.UploadURL, pathToRoot)
 	if err != nil {
 		return err

--- a/cmd/speculative_plan.go
+++ b/cmd/speculative_plan.go
@@ -28,6 +28,7 @@ var speculativePlanCmd = &cobra.Command{
 		config := speculativePlanConfig{
 			Config: baseConfig,
 
+			RootPath:  viper.GetString("rootpath"),
 			Path:      viper.GetString("path"),
 			Workspace: viper.GetString("workspace"),
 		}
@@ -39,6 +40,7 @@ var speculativePlanCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(speculativePlanCmd)
 
+	flags.AddRootPathFlag(speculativePlanCmd)
 	flags.AddPathFlag(speculativePlanCmd)
 	flags.AddWorkspaceFlag(speculativePlanCmd)
 	flags.AddAutoApplyFlag(speculativePlanCmd)
@@ -54,6 +56,7 @@ func init() {
 type speculativePlanConfig struct {
 	config.Config
 
+	RootPath  string
 	Path      string
 	Workspace string
 
@@ -77,8 +80,8 @@ func speculativePlan(cfg speculativePlanConfig) error {
 		return err
 	}
 	var pathToRoot string
-	if cfg.mockGit {
-		pathToRoot = "pathToRoot"
+	if cfg.RootPath != "" {
+		pathToRoot = cfg.RootPath
 	} else {
 		pathToRoot, _, err = git.GetRootOfRepo(cfg.Path)
 		if err != nil {
@@ -86,6 +89,7 @@ func speculativePlan(cfg speculativePlanConfig) error {
 		}
 	}
 
+	fmt.Println("[debug] speculative plan, root path:", pathToRoot)
 	err = cfg.Client.ConfigurationVersions.Upload(cfg.Ctx, cv.UploadURL, pathToRoot)
 	if err != nil {
 		return err

--- a/cmd/speculative_plan_test.go
+++ b/cmd/speculative_plan_test.go
@@ -62,7 +62,7 @@ func TestSpeculativePlan(t *testing.T) {
 			Upload(
 				gomock.Any(),
 				"http://foobar.example.com",
-				"pathToRoot", // manually mocked inside speculativePlan function
+				"pathToRoot",
 			).
 			Return(nil),
 		runsMock.EXPECT().
@@ -103,6 +103,7 @@ func TestSpeculativePlan(t *testing.T) {
 
 	speculativePlanConfig := speculativePlanConfig{
 		Config:    cfg,
+		RootPath:  "pathToRoot",
 		Path:      "",
 		Workspace: "testWS",
 		mockGit:   true,

--- a/cmd/upload_config.go
+++ b/cmd/upload_config.go
@@ -26,6 +26,7 @@ var uploadConfigCmd = &cobra.Command{
 		config := &uploadConfigConfig{
 			Config: baseConfig,
 
+			RootPath:  viper.GetString("rootpath"),
 			Path:      viper.GetString("path"),
 			Workspace: viper.GetString("workspace"),
 		}
@@ -37,13 +38,14 @@ var uploadConfigCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(uploadConfigCmd)
 
-	flags.AddPathFlag(uploadConfigCmd)
+	flags.AddRootPathFlag(uploadConfigCmd)
 	flags.AddWorkspaceFlag(uploadConfigCmd)
 }
 
 type uploadConfigConfig struct {
 	config.Config
 
+	RootPath  string
 	Path      string
 	Workspace string
 }
@@ -63,11 +65,16 @@ func uploadConfig(cfg *uploadConfigConfig) error {
 		return err
 	}
 
-	pathToRoot, _, err := git.GetRootOfRepo(cfg.Path)
-	if err != nil {
-		return err
-	}
+	var pathToRoot string
+	if cfg.RootPath != "" {
+		pathToRoot = cfg.RootPath
+	} else {
+		pathToRoot, _, err = git.GetRootOfRepo(cfg.Path)
 
+		if err != nil {
+			return err
+		}
+	}
 	err = cfg.Client.ConfigurationVersions.Upload(cfg.Ctx, cv.UploadURL, pathToRoot)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/go-tfe v1.52.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
I've added an option "--rootpath" which will override the git workspace root. With this option, git isn't called to find the root.

But I couldn't get it working properly on my VM: the command-line options are always ignored (although setting env-vars works). I don't know if this is something to do with the "buildVersion" stuff or what.