### PR TITLE
bind flags in cmd init

### DIFF
--- a/cmd/flags/validate.go
+++ b/cmd/flags/validate.go
@@ -1,9 +1,12 @@
 package flags
 
 import (
+	"fmt"
+
 	"github.com/logandavies181/tfd/v2/cmd/config"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -29,15 +32,20 @@ func addValidation(name string, validationFunc func() error) {
 	}
 }
 
-func InitializeCmd(cmd *cobra.Command) (conf config.Config, err error) {
-	conf, err = config.New()
+func InitializeCmd(cmd *cobra.Command) (config.Config, error) {
+	conf, err := config.New()
 	if err != nil {
-		return
+		return config.Config{}, fmt.Errorf("could not create new config object: %w", err)
+	}
+
+	err = viper.BindPFlags(cmd.Flags())
+	if err != nil {
+		return config.Config{}, fmt.Errorf("could not bind flags: %w", err)
 	}
 
 	err = validateFlags(cmd.Name())
 	if err != nil {
-		return
+		return config.Config{}, err // just let the validation error display as-is
 	}
 
 	return conf, nil

--- a/cmd/speculative_plan.go
+++ b/cmd/speculative_plan.go
@@ -125,7 +125,7 @@ func speculativePlan(cfg speculativePlanConfig) error {
 	if planError == nil {
 		fmt.Println(plan.FormatResourceChanges(runPlan))
 	} else {
-		fmt.Println(planError)
+		fmt.Println(planError.Error())
 	}
 
 	return nil


### PR DESCRIPTION
overzealously removed all bindflags calls except for one, which only had root persistent flags.

Also fix up plan error message